### PR TITLE
Added c_cpp_properties file so vscode doesn't show invalid errors

### DIFF
--- a/firmware/.vscode/c_cpp_properties.json
+++ b/firmware/.vscode/c_cpp_properties.json
@@ -1,0 +1,27 @@
+{
+    "configurations": [
+        {
+            "name": "nRF SDK 16.0.0",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "forcedInclude": [
+                "${workspaceFolder}/nRF5_SDK_16.0.0/sdk_config.h"
+            ],
+            "defines": [
+                "BOARD_PCA10059",
+                "FLOAT_ABI_HARD",
+                "NRF52",
+                "NRF52840_XXAA",
+                "NRF_SD_BLE_API_VERSION=6",
+                "S340",
+                "SOFTDEVICE_PRESENT"
+            ],
+            "compilerPath": "/usr/bin/arm-none-eabi-gcc",
+            "cStandard": "c11",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "clang-x64"
+        }
+    ],
+    "version": 4
+  }


### PR DESCRIPTION
Was getting a lot of errors whilst viewing in VS Code so borrowed a configuration file from https://github.com/justinmklam/nrf52-blinky-demo/blob/master/.vscode/c_cpp_properties.json and modified it slightly. I'm new to VS Code so it might not be correct but it is certainly throwing less invalid errors then before