### PR TITLE
feat: add in cortex-debug script

### DIFF
--- a/firmware/.vscode/launch.json
+++ b/firmware/.vscode/launch.json
@@ -96,5 +96,43 @@
                 }
             ]
         },
+        {
+            // Cortex Debug Configuration: https://marcelball.ca/projects/cortex-debug/cortex-debug-launch-configurations/
+            // Cannot attach to existing OpenOCD Server so have to halt previous first 
+            "name": "NRF52 Debug (Cortex)",
+            "type": "cortex-debug",
+            "request": "launch",
+            //  OpenOCD path is defined in workspace.code-workspace.
+            "executable": "${workspaceFolder}/_build/TSDZ2_wireless.out",
+            "servertype": "openocd",
+            "cwd": "${workspaceRoot}",
+            //  Application Executable to be flashed before debugging
+            "device": "nRF52840",
+            //  Arm System View Description, from apache-mynewt-core/hw/mcu/nordic/src/ext/nrfx/mdk
+            "svdFile": "${workspaceRoot}/nRF5_SDK_16.0.0/modules/nrfx/mdk/nrf52840.svd",
+            "configFiles": [ 
+                //  Tell OpenOCD to open the ST Link connection to nRF52 MCU.
+                "tools/openocd-v0.10.0-scripts/stlink-v2.cfg",
+                "tools/openocd-v0.10.0-scripts/nrf52.cfg",
+            ],
+            "preLaunchCommands": [
+                //  Before loading the Application, run these gdb commands.
+                //  Set timeout for executing openocd commands.
+                "set remotetimeout 60",
+
+                //  This indicates that an unrecognized breakpoint location should automatically result in a pending breakpoint being created.
+                // "set breakpoint pending on"
+            ],
+            "postLaunchCommands": [
+                //  After loading the Application, run these gdb commands
+                //  "break main",                   //  Break at main()
+                //  "break __assert_func",          //  Break for any assert failures
+                //  "break os_default_irq"          //  Break for any unhandled interrupts
+            ],
+            "preRestartCommands": [
+            ],
+            "postRestartCommands": [
+            ]        
+        }     
     ]
 }


### PR DESCRIPTION
Adds in new launch option to run the cortex debugger (along with  `Arm System View Description`). This gives system registers and a much better populated variable stack. The only downside is that I cannot find a way to get it to use the existing openocd connection so you have to stop that first before running the cortex debugger.

![cortex-debug](https://user-images.githubusercontent.com/2067021/89111632-13a0d100-d450-11ea-936a-fb394d1b5de7.png)
